### PR TITLE
Fix wrong supported release of Hitachi HUS driver

### DIFF
--- a/etc/default_data.json
+++ b/etc/default_data.json
@@ -904,8 +904,7 @@
                 "Havana",
                 "Icehouse",
                 "Juno",
-                "Kilo",
-                "Liberty"
+                "Kilo"
             ]
         },
         {


### PR DESCRIPTION
The Hitachi HUS driver was deprecated in Liberty[1]. Therefore, it should not be
listed as supported in Liberty.

[1] https://goo.gl/RaEUiG